### PR TITLE
docs: add First PR Checklist to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Telegramで操作する、安全ガバナンス型のローカル作業アシス
 - 初心者向けIssue: `Issues` で `good first issue` ラベルを選択
 - 改善要望/不具合報告: `Issues > New issue` でテンプレートを選択
 
+### First PR Checklist 📝
+Before submitting your first PR, make sure you've completed these steps:
+
+- [ ] Found a `good first issue` or `help wanted` issue and commented to claim it
+- [ ] Created a descriptive branch name (e.g., `docs/fix-typo`, `feat/add-feature`)
+- [ ] Made your changes following the [Contributing Guide](CONTRIBUTING.md)
+- [ ] Ran tests locally: `python -m pytest -q`
+- [ ] Kept the PR focused on one purpose
+- [ ] Added or updated tests if needed
+- [ ] Filled out the PR template completely
+- [ ] No secrets, API keys, or sensitive data in your changes
+
+💡 **Tip**: If you're stuck, don't hesitate to ask questions in the Issue. We're here to help!
+
 ### 配布用パッケージを自動生成
 開発用の `tests/.taskmaster/data` などを除外し、配布に必要なファイルだけを出力します。
 


### PR DESCRIPTION
## Summary
Adds a concise **First PR Checklist** section to help first-time contributors submit PRs with less confusion.

## Changes
- Added `### First PR Checklist 📝` section in README.md
- 8 actionable checklist items covering the full PR workflow
- Links to [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines
- Includes beginner-friendly tip to encourage questions

## Definition of Done ✅
- [x] Checklist is concise (8 bullets)
- [x] Link to CONTRIBUTING exists
- [x] Language is beginner-friendly

## Related Issue
Closes #3

## Why This Matters
This checklist will:
- Reduce confusion for first-time contributors
- Improve PR quality by setting clear expectations
- Decrease back-and-forth during reviews
- Make the project more welcoming to newcomers

## Testing
- Verified the checklist renders correctly on GitHub
- Ensured all links work properly
- Confirmed markdown formatting is clean

---
_This is a documentation-only change with no code modifications._